### PR TITLE
Displays Faction Selection as a List, Increases Selection Window Size

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -425,9 +425,9 @@
 			continue
 
 		if (faction.name == selected_faction)
-			factions += "[faction.name]"
+			factions += "[faction.name]<br>" //NEW HORIZONS EDIT
 		else
-			factions += "<a href='?src=\ref[src];faction_preview=[html_encode(faction.name)]'>[faction.name]</a>"
+			factions += "<a href='?src=\ref[src];faction_preview=[html_encode(faction.name)]'>[faction.name]</a><br>" //NEW HORIZONS EDIT
 
 	dat += factions.Join(" ")
 
@@ -461,7 +461,7 @@
 		dat += "<br><span class='warning'>[faction.get_selection_error(pref, user)]</span>"
 	dat += "</center>"
 
-	user << browse(dat.Join(), "window=factionpreview;size=750x450")
+	user << browse(dat.Join(), "window=factionpreview;size=750x800") //NEW HORIZONS EDIT
 
 /datum/category_item/player_setup_item/occupation/proc/validate_and_set_faction(selected_faction)
 	var/datum/faction/faction = SSjobs.name_factions[selected_faction]


### PR DESCRIPTION
## About The Pull Request

Displays the faction selection as a list rather than a bundle of overflowing hyperlinks (and increases the window size to accommodate).

| Before | After |
| --- | --- |
| ![image](https://github.com/New-Horizontes/New-Horizons/assets/49307226/60195e4a-4f13-47ed-98f8-1f0dc6581952) | ![image](https://github.com/New-Horizontes/New-Horizons/assets/49307226/0aab9945-0234-4f04-98cb-4e43cfb8d82a) |

Window height has only been extended to 800 to accommodate for our beloved 1080p gamers.

## Why It's Good For The Game

Better UI/UX in lieu of the window being TGUIed.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Makes faction selection listed (not bundled).
/:cl:
