### PR TITLE
IPC: The Pronouning

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -11,7 +11,7 @@
 	age_max = 60
 	economic_modifier = 3
 	default_genders = list(NEUTER)
-	selectable_pronouns = list(NEUTER, PLURAL)
+	selectable_pronouns = list(MALE, FEMALE, NEUTER, PLURAL) //New Horizons edit
 
 	blurb = "IPCs are, quite simply, \"Integrated Positronic Chassis.\" In this scenario, 'positronic' implies that the chassis possesses a positronic processing core (or positronic brain), meaning that an IPC must be positronic to be considered an IPC. The Baseline model is more of a category - the long of the short is that they represent all unbound synthetic units. Baseline models cover anything that is not an Industrial chassis or a Shell chassis. They can be custom made or assembly made. The most common feature of the Baseline model is a simple design, skeletal or semi-humanoid, and ordinary atmospheric diffusion cooling systems."
 


### PR DESCRIPTION
"Surely, if I make just one change I won't cause any conflicts with the big lore PR"

Non-shell IPCs can now identify with whatever gender they please. This was shut down on Aurora a while back for completely nonsensical reasons, so we're bringing it back.

Also makes more sense considering the increased usage of brain scans in our version of IPC lore.
